### PR TITLE
Imports glue from CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     stringr,
-    glue (>= 1.2.0.9000),
+    glue (>= 1.3.0),
     crayon,
     utils,
     magrittr,
@@ -29,4 +29,3 @@ BugReports: https://github.com/hadley/emo/issues
 Suggests: 
     testthat,
     dplyr
-Remotes: tidyverse/glue


### PR DESCRIPTION
closes #53 

Glue is now 1.3.1 on CRAN so this is no more required I guess.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hadley/emo/54)
<!-- Reviewable:end -->
