### PR TITLE
corrected typos in ji_locate documentation

### DIFF
--- a/R/ji_rx.R
+++ b/R/ji_rx.R
@@ -88,7 +88,7 @@ ji_replace <- function( string, replacement) str_replace(string, emo::ji_rx, rep
 #' @export
 ji_replace_all <- function(string, replacement) str_replace_all(string, emo::ji_rx, replacement)
 
-#' Lodate the positio of emojis in a string
+#' Locate the position of emojis in a string
 #'
 #' Vectorised over `string`
 #'


### PR DESCRIPTION
Noticed a typo while working with the package as part of a class assignment. Made sure to update the `ji_rx.R` file and not the `roxygen2`-generated file